### PR TITLE
Add dynamic table option

### DIFF
--- a/irregularUtils.js
+++ b/irregularUtils.js
@@ -128,7 +128,7 @@ define([], function () {
                     var selectedTablesStr = selectedTables.map(function (e) { return '"' + e + '"' }).join(",");
 
                     var hideColIfNotPresentFormula = "Sum($Field='&CHR(39)&$Field&CHR(39)&')";
-                    var hideColIfNotSelectedFormula = "WildMatch(Chr(44)&Chr(32)&Concat(GetFieldSelections([" + layout.dynamicTableDimensionName + "]), Chr(44)&Chr(32))&Chr(44), '&Chr(39)&Chr(42)&Chr(44)&Chr(32)&$Field&Chr(44)&Chr(42)&CHR(39)&')";
+                    var hideColIfNotSelectedFormula = "WildMatch(Chr(166)&GetFieldSelections([" + layout.dynamicTableDimensionName + "], Chr(166), 1000)&Chr(166), '&Chr(39)&Chr(42)&Chr(166)&$Field&Chr(166)&Chr(42)&Chr(39)&')";
                     var hideCol = layout.hideColIfNotPresent||layout.hideColIfNotSelected;
 
                     if (layout.hideColIfNotPresent && layout.hideColIfNotSelected) {

--- a/irregularUtils.js
+++ b/irregularUtils.js
@@ -127,13 +127,27 @@ define([], function () {
                 if (res) {
                     var selectedTablesStr = selectedTables.map(function (e) { return '"' + e + '"' }).join(",");
 
+                    var hideColIfNotPresentFormula = "Sum($Field='&CHR(39)&$Field&CHR(39)&')";
+                    var hideColIfNotSelectedFormula = "WildMatch(Chr(44)&Chr(32)&Concat(GetFieldSelections([" + layout.dynamicTableDimensionName + "]), Chr(44)&Chr(32))&Chr(44), '&Chr(39)&Chr(42)&Chr(44)&Chr(32)&$Field&Chr(44)&Chr(42)&CHR(39)&')";
+                    var hideCol = layout.hideColIfNotPresent||layout.hideColIfNotSelected;
+
+                    if (layout.hideColIfNotPresent && layout.hideColIfNotSelected) {
+                        var hideColFormula = hideColIfNotPresentFormula + " And " + hideColIfNotSelectedFormula;
+                    }
+                    else if (layout.hideColIfNotPresent) {
+                        var hideColFormula = hideColIfNotPresentFormula;
+                    }
+                    else if (layout.hideColIfNotSelected) {
+                        var hideColFormula = hideColIfNotSelectedFormula;
+                    }
+
                     var setModifier = '{<$Table={' + selectedTablesStr + '},'
                         + '$Field={"(' + layout.fieldPattern + ')"}-{"(' + layout.ignoreFieldPattern + ')"}>}';
                     // Use engine-formula to get a field list ... Concat($Field,',')
                     var fieldQFormula = "=Concat(" + setModifier + " '{\"qDef\":{\"qFieldDefs\":[\"' & $Field & '\"],\"qFieldLabels\":[\"' & "
                         + (layout.boolRemovePrefix ? "If(Index($Field,'.'),Mid($Field,Index($Field,'.')+1),$Field)" : "$Field")
                         + "&'\"]}"
-                        + (layout.hideColIfNotPresent ? ", \"qCalcCondition\":{\"qCond\":{\"qv\":\"=Sum($Field=' & CHR(39) & $Field & CHR(39) & ')\"}}" : "")
+                        + (hideCol ? ", \"qCalcCondition\":{\"qCond\":{\"qv\":\"=" + hideColFormula + "\"}}" : "")
                         + "}', ',', $FieldNo)";
 
                     app.model.enigmaModel.evaluate(fieldQFormula)

--- a/irregularUtils.js
+++ b/irregularUtils.js
@@ -128,7 +128,7 @@ define([], function () {
                     var selectedTablesStr = selectedTables.map(function (e) { return '"' + e + '"' }).join(",");
 
                     var hideColIfNotPresentFormula = "Sum($Field='&CHR(39)&$Field&CHR(39)&')";
-                    var hideColIfNotSelectedFormula = "WildMatch(Chr(166)&GetFieldSelections([" + layout.dynamicTableDimensionName + "], Chr(166), 1000)&Chr(166), '&Chr(39)&Chr(42)&Chr(166)&$Field&Chr(166)&Chr(42)&Chr(39)&')";
+                    var hideColIfNotSelectedFormula = "WildMatch(Chr(124)&GetFieldSelections([" + layout.dynamicTableDimensionName + "], Chr(124), 1000)&Chr(124), '&Chr(39)&Chr(42)&Chr(124)&$Field&Chr(124)&Chr(42)&Chr(39)&')";
                     var hideCol = layout.hideColIfNotPresent||layout.hideColIfNotSelected;
 
                     if (layout.hideColIfNotPresent && layout.hideColIfNotSelected) {

--- a/properties.js
+++ b/properties.js
@@ -105,6 +105,16 @@ define(["qlik", "./irregularUtils"
                     ref: "hideColIfNotPresent",
                     defaultValue: true
                 }, {
+                    label: 'Setup as a dynamic table',
+                    type: 'boolean',
+                    ref: "hideColIfNotSelected",
+                    defaultValue: false
+                }, {
+                    label: 'Dynamic table dimension name',
+                    type: 'string',
+                    ref: "dynamicTableDimensionName",
+                    defaultValue: "Dimension"
+                }, {
                     label: "Get my table!",
                     component: "button",
                     action: function (context) { utils.convertToTable(qlik, context); }


### PR DESCRIPTION
I just stumbled upon your later version of this extension and saw that you had added the conditional show if field doesn't exist.
This enabled me, with my limited knowledge, to add the dynamic table option I've longing for.

I spend hours upon hours manually creating tables and adding the correct conditional show formula.
This is my solution to it.

I've added a checkbox for the function, and also a text input to allow the user to specify what field should be used in GetFieldSelections().